### PR TITLE
[Rspec test] Added test to request sales endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,11 @@ source 'https://rubygems.org'
 gem 'spree', '~> 3.4.4'
 # Provides basic authentication functionality for testing parts of your engine
 gem 'spree_auth_devise', '~> 3.3'
-gem 'rails-controller-testing'
+
+group :test do
+    gem 'rails-controller-testing'
+    gem 'rspec-rails', '~> 3.7.2'
+    gem 'rspec-activemodel-mocks'
+end
 
 gemspec

--- a/app/controllers/spree/api/v1/sales_controller.rb
+++ b/app/controllers/spree/api/v1/sales_controller.rb
@@ -3,7 +3,7 @@ module Spree
         module V1
             class SalesController < Spree::Api::BaseController
                 def index
-                    @products = Spree::Product.joins(:variants_including_master).where('spree_variants.sale_price is not null').distinct
+                    @products = Spree::Product.joins(:variants_including_master).where('spree_variants.sale_price is not null').uniq
                     
                     expires_in 15.minutes, public: true
                     

--- a/app/views/spree/api/v1/sales/index.v1.rabl
+++ b/app/views/spree/api/v1/sales/index.v1.rabl
@@ -1,2 +1,2 @@
 collection @products
-attributes *product_attributes
+attributes *product_attributes << :sale_price

--- a/spec/controllers/spree/api/v1/sales_controller_spec.rb
+++ b/spec/controllers/spree/api/v1/sales_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module Spree
+    describe Api::V1::SalesController, type: :controller do
+        
+        render_views
+
+        let!(:product) { create(:product, sale_price: 8.00)  }
+        let!(:other_product) { create(:product) }
+        let!(:user) { create(:user) }
+
+        before do
+            stub_authentication!
+        end
+
+        it 'retrieves a list of products in sale' do
+            api_get :index
+            expect(json_response.size).to eq(1)
+            expect(json_response.first["sale_price"].to_f).to eq(product.sale_price)
+        end
+    end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,11 @@ require 'spree/testing_support/controller_requests'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 
+require 'spree/testing_support/preferences'
+require 'spree/api/testing_support/caching'
+require 'spree/api/testing_support/helpers'
+require 'spree/api/testing_support/setup'
+
 # Requires factories defined in lib/spree_simple_sales/factories.rb
 require 'spree_simple_sales/factories'
 
@@ -58,6 +63,20 @@ RSpec.configure do |config|
   # Adds convenient methods to request Spree's controllers
   # spree_get :index
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
+
+  config.include FactoryBot::Syntax::Methods
+  config.include Spree::Api::TestingSupport::Helpers, type: :controller
+  config.extend Spree::Api::TestingSupport::Setup, type: :controller
+  config.include Spree::TestingSupport::Preferences, type: :controller
+
+  config.before do
+    Spree::Api::Config[:requires_authentication] = true
+  end
+
+  config.include VersionCake::TestHelpers, type: :controller
+  config.before(:each, type: :controller) do
+      set_request_version('', 1)
+  end
 
   # == Mock Framework
   #

--- a/spec/support/controller_hacks.rb
+++ b/spec/support/controller_hacks.rb
@@ -1,0 +1,43 @@
+#
+# Copied from Spree core repo: https://github.com/spree/spree/blob/master/api/spec/support/controller_hacks.rb
+#
+require 'active_support/all'
+module ControllerHacks
+  extend ActiveSupport::Concern
+
+  included do
+    routes { Spree::Core::Engine.routes }
+  end
+
+  def api_get(action, params = {}, session = nil, flash = nil)
+    api_process(action, params, session, flash, 'GET')
+  end
+
+  def api_post(action, params = {}, session = nil, flash = nil)
+    api_process(action, params, session, flash, 'POST')
+  end
+
+  def api_put(action, params = {}, session = nil, flash = nil)
+    api_process(action, params, session, flash, 'PUT')
+  end
+
+  def api_delete(action, params = {}, session = nil, flash = nil)
+    api_process(action, params, session, flash, 'DELETE')
+  end
+
+  def api_process(action, params = {}, session = nil, flash = nil, method = 'get')
+    scoping = respond_to?(:resource_scoping) ? resource_scoping : {}
+    process(
+      action,
+      method: method,
+      params: params.merge(scoping),
+      session: session,
+      flash: flash,
+      format: :json
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include ControllerHacks, type: :controller
+end

--- a/spec/support/spec_view_helpers.rb
+++ b/spec/support/spec_view_helpers.rb
@@ -1,0 +1,21 @@
+
+#
+# Use view helpers methods into rspec tests
+#
+# @see https://gist.github.com/dimroc/60b9f419f9bc23f8be4e650346b58f6e
+#
+module ViewHelpers
+  def h
+    ViewHelper.instance
+  end
+
+  class ViewHelper
+    include Singleton
+    include ActionView::Helpers::NumberHelper
+    include ApplicationHelper
+  end
+end
+
+RSpec.configure do |config|
+  config.include ViewHelpers
+end


### PR DESCRIPTION
Added a spec integration test to verify if the new endpoint `/sales` json response.

The official documentation was updated to cover this changes into a separated PR for Spree core: [spree/!8665](https://github.com/spree/spree/pull/8665)